### PR TITLE
SEO: shorten over-length titles and trim descriptions on top-traffic posts

### DIFF
--- a/content/posts/2021/2021-01-19-mac1-metal-EC2-Instance-user-experience/index.md
+++ b/content/posts/2021/2021-01-19-mac1-metal-EC2-Instance-user-experience/index.md
@@ -1,6 +1,6 @@
 ---
 date: "2021-01-19T00:00:00Z"
-title: "mac1.metal and mac2.metal EC2 Instances: Pricing, Specs & Hands-on Review"
+title: "mac1.metal & mac2.metal EC2: Pricing, Specs & Review"
 slug: mac1.metal-and-mac2.metal-ec2-instances-user-experience
 description: "A hands-on review of AWS mac1.metal and mac2.metal EC2 instances — pricing, specs, performance, AMI customization, and the 24-hour minimum allocation gotcha."
 summary: "Hands-on review of AWS mac1.metal and mac2.metal EC2 instances: pricing, specs, and practical gotchas."

--- a/content/posts/2021/aws-ram-multi-account-resource-organization/index.md
+++ b/content/posts/2021/aws-ram-multi-account-resource-organization/index.md
@@ -1,5 +1,6 @@
 ---
 title: "AWS Resource Access Manager — Multi Account Resource Governance"
+slug: aws-resource-access-manager-multi-account-resource-governance
 date: 2021-09-25T00:54:23+03:00
 description: Provision and manage resources within the AWS Organization with ease
 summary: Provision and manage resources within the AWS Organization with ease

--- a/content/posts/2021/aws-ram-multi-account-resource-organization/index.md
+++ b/content/posts/2021/aws-ram-multi-account-resource-organization/index.md
@@ -1,5 +1,5 @@
 ---
-title: "AWS Resource Access Manager — Multi Account Resource Governance"
+title: "AWS Resource Access Manager: Multi-Account Governance"
 slug: aws-resource-access-manager-multi-account-resource-governance
 date: 2021-09-25T00:54:23+03:00
 description: Provision and manage resources within the AWS Organization with ease

--- a/content/posts/2023/hello-terraform-data-goodbye-null-resource/index.md
+++ b/content/posts/2023/hello-terraform-data-goodbye-null-resource/index.md
@@ -1,9 +1,9 @@
 ---
-title: "terraform_data vs null_resource: The Built-in Replacement in Terraform 1.4"
+title: "terraform_data vs null_resource: Terraform 1.4 Migration"
 slug: hello-terraform-data-goodbye-null-resource
 date: 2023-04-16T01:25:18+02:00
 summary: "terraform_data is the native replacement for null_resource starting with Terraform 1.4."
-description: "terraform_data replaces null_resource in Terraform 1.4 as a built-in managed resource. See the differences, use cases with triggers_replace and provisioners, plus migration examples."
+description: "terraform_data replaces null_resource in Terraform 1.4 — see the differences, use cases with triggers_replace and provisioners, plus migration examples."
 cover:
     image: cover-image.png
     relative: true

--- a/content/posts/2024/A-Deep-Dive-Into-Terraform-Static-Code-Analysis-Tools-Features-and-Comparisons/index.md
+++ b/content/posts/2024/A-Deep-Dive-Into-Terraform-Static-Code-Analysis-Tools-Features-and-Comparisons/index.md
@@ -1,13 +1,13 @@
 ---
-title: "Terraform Static Code Analysis Tools Compared: Checkov, Trivy, KICS & More"
+title: "Terraform SAST Tools Compared: Checkov, Trivy, KICS"
 slug: a-deep-dive-into-terraform-static-code-analysis-tools-features-and-comparisons
 date: 2024-04-16T21:14:15+02:00
 summary: "Side-by-side comparison of 6 Terraform static analysis tools: Checkov, Trivy, KICS, Terrascan, tfsec, and Semgrep."
-description: "Compare 6 Terraform static code analysis tools — Checkov, Trivy, KICS, Terrascan, tfsec, Semgrep — across built-in policies, custom rules, CI/CD integrations, and output formats."
+description: "Compare 6 Terraform SAST tools — Checkov, Trivy, KICS, Terrascan, tfsec, Semgrep — across policies, custom rules, and CI/CD integrations."
 cover:
     image: cover-image.png
     relative: true
-    alt: "Terraform Static Code Analysis Tools"
+    alt: "Side-by-side comparison of Checkov, Trivy, KICS, Terrascan, tfsec, and Semgrep for Terraform security scanning"
 tags: [terraform,security,compliance,infrastructure-as-code,static-code-analysis]
 categories: [Terraform]
 series: ["Terraform Proficiency"]

--- a/content/posts/2024/Mastering-AWS-API-Gateway-V2-HTTP-and-AWS-Lambda-with-Terraform/index.md
+++ b/content/posts/2024/Mastering-AWS-API-Gateway-V2-HTTP-and-AWS-Lambda-with-Terraform/index.md
@@ -1,9 +1,9 @@
 ---
-title: "AWS API Gateway V2 + Lambda with Terraform: A Complete Guide"
+title: "Terraform AWS API Gateway V2 + Lambda Guide"
 slug: mastering-aws-api-gateway-v2-http-and-aws-lambda-with-terraform
 date: 2024-01-09T03:33:10+01:00
 summary: Step-by-step guide to building a serverless backend with API Gateway V2 HTTP API and Lambda using Terraform.
-description: "Step-by-step Terraform guide to AWS API Gateway V2 HTTP API with Lambda authorizer, backend integration, custom domain, routes, stages, and CloudWatch monitoring."
+description: "Step-by-step Terraform guide to AWS API Gateway V2 with Lambda authorizer, backend integration, custom domain, routes, and stages."
 cover:
     image: cover-image.jpg
     relative: true

--- a/content/posts/2025/aws-s3-cost-optimization-removing-redundancy-and-implementing-intelligent-tiering/index.md
+++ b/content/posts/2025/aws-s3-cost-optimization-removing-redundancy-and-implementing-intelligent-tiering/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Aws S3 Cost Optimization: Removing Redundancy and Implementing Intelligent Tiering"
+title: "AWS S3 Cost Optimization with Intelligent Tiering"
 slug: aws-s3-cost-optimization-removing-redundancy-and-implementing-intelligent-tiering
 date: 2025-01-29T02:48:15+01:00
 summary: Legacy setups can hide costs, and sometimes big. By challenging this, I learned some cool stuff about S3 Intelligent-Tiering and Lifecycle Configuration.

--- a/content/posts/2025/aws-s3-cost-optimization-removing-redundancy-and-implementing-intelligent-tiering/index.md
+++ b/content/posts/2025/aws-s3-cost-optimization-removing-redundancy-and-implementing-intelligent-tiering/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Aws S3 Cost Optimization: Removing Redundancy and Implementing Intelligent Tiering"
+slug: aws-s3-cost-optimization-removing-redundancy-and-implementing-intelligent-tiering
 date: 2025-01-29T02:48:15+01:00
 summary: Legacy setups can hide costs, and sometimes big. By challenging this, I learned some cool stuff about S3 Intelligent-Tiering and Lifecycle Configuration.
 description: Legacy setups can hide costs, and sometimes big. By challenging this, I learned some cool stuff about S3 Intelligent-Tiering and Lifecycle Configuration.


### PR DESCRIPTION
## Summary
- Shortens 6 over-length post titles to under 60 chars (raw, before the ` | devDosvid blog` suffix) so Google stops truncating them mid-phrase in SERPs.
- Trims 3 over-length descriptions from 164/181/191 chars down to 130/137/152 chars, putting them inside Google's 120–155 display window.
- Fixes a casing bug on the s3-cost-optimization title (`Aws` → `AWS`).
- Front-loads "Terraform" in the api-gateway-v2 title to strengthen the signal for three "API Gateway Terraform" page-2 queries currently ranking positions 10–35.
- Replaces the generic cover alt on the terraform-sast comparison post with one that names the 6 compared tools.
- Locks permalinks on the s3-cost and aws-ram posts via explicit `slug:` fields so the URLs are deterministic and decoupled from the title (the aws-ram post was previously relying on Hugo's `urlize(title)` fallback — renaming the title would have silently broken the permalink).

## Why

SEO audit over the last 90 days (Feb 3 – May 2, 2026) returned **569 clicks / 166K impressions = 0.3% average CTR at average position 8.1**. Position 8 normally pulls 1–3% CTR, so the site has strong visibility but anemic SERP click-through.

Top finding: 5 of the top 10 traffic-getting posts have over-length titles truncated in search results, and 3 have descriptions over Google's display window. This is the highest-ROI lever the audit identified.

**Estimated impact**: a +0.5% CTR lift across the 4 highest-impression affected posts (api-gateway-v2 alone gets 61.8K impressions / 90 days at 0.1% CTR) would be roughly **+500 clicks per quarter**.

## Verification

- All 6 affected URLs return HTTP 200 after the changes (local Docker dev server).
- Sitemap diff before/after: **zero `<loc>` URL changes** (only `<lastmod>` differs, as expected).
- All 6 raw titles now ≤ 60 chars; all 3 modified descriptions land in the 120–155 range.
- Hugo build clean across 12 incremental rebuilds — no errors or warnings.
- aws-ram regression check: the URL Hugo *would have* generated from the new title (without the slug-locking commit) returns 404, while the live URL returns 200 — confirming the slug-locking step prevented a permalink regression.

## Out of scope

Deferred for follow-up:
- 40 pages in "Crawled — currently not indexed" state in GSC.
- Minimal cannibalization findings.
- Further page-2 query optimization beyond the api-gateway title front-load.
