### PR TITLE
Restructure leadership cluster for search visibility

### DIFF
--- a/config/_default/config.yaml
+++ b/config/_default/config.yaml
@@ -93,8 +93,8 @@ params:
     twittercreator: "@vasylenko"
     ShowLicense: true
     title: devDosvid blog
-    description: "Writing about technical leadership, platform engineering, and the practices that help teams and infrastructure scale."
-    keywords: [Technical Blog, DevOps, AWS, Terraform, Ukraine, Tutorials, Education, Developer Experience, Infrastructure, Explanations]
+    description: "Engineering leadership and platform engineering essays — staff engineer growth, leading without authority, and the practices that help teams and infrastructure compound over time."
+    keywords: [Engineering Leadership, Staff Engineer, Platform Engineering, Leading Without Authority, Senior Engineer Career, Tech Lead, DevOps, AWS, Terraform, Developer Experience, Infrastructure, Engineering Management]
     author: Serhii Vasylenko
     images: ["/assets/img/websitelogo.jpg"]
     DateFormat: "January 2, 2006"
@@ -137,7 +137,7 @@ params:
 
     homeInfoParams:
         Title: "devDosvid blog"
-        Content: "There are many engineering blogs, but this one is mine — writing about technical leadership, platform engineering, and the practices that help teams and infrastructure scale."
+        Content: "Essays on engineering leadership and platform engineering — staff engineer growth, leading without authority, and the practices that help teams and infrastructure compound over time. There are many engineering blogs; this one is mine."
     cover:
         hidden: false # hide everywhere but not in structured data
         hiddenInList: false # hide on list pages and home

--- a/content/about/index.md
+++ b/content/about/index.md
@@ -14,9 +14,9 @@ ShowLicense: false
 
 {{< author-intro name="Serhii Vasylenko" role="Staff Platform Engineer" company="Superhuman" company_url="https://superhuman.com" >}}
 
-Hi, I'm Serhii. I build solutions that help engineering teams ship faster and more safely — focusing on developer experience, infrastructure platforms, and security automation.
+Hi, I'm Serhii. I'm a Staff Platform Engineer at Superhuman (formerly Grammarly), leading the design and operation of developer-experience and infrastructure-platform systems that help engineering teams ship faster and more safely. Across my career I've grown teams, mentored peers, and learned to lead and influence without formal authority — patterns I write about here alongside the technical work that makes large platforms reliable.
 
-You can read more about my professional background [in my CV](/cv).
+You'll find the leadership writing in the [Engineering Leadership series](/series/engineering-leadership/), the platform and infrastructure work across [all posts](/archive), and a fuller professional history [in my CV](/cv).
 
 Technical blogging is my hobby; I'm also fond of astronomy and history.
 

--- a/content/posts/2022/some-techniques-to-enhance-your-terraform-proficiency/index.md
+++ b/content/posts/2022/some-techniques-to-enhance-your-terraform-proficiency/index.md
@@ -287,6 +287,8 @@ Terraform is far beyond the standard resource management operations. With the po
 
 ✅ And when you need to pass some files to the managed service, you can treat them as [templates](https://www.terraform.io/language/functions/templatefile) and make them multipurpose.
 
+Once these patterns become reflexive on a single service, the next-level problem is applying them across many services at once — without burning out the team. I wrote a separate post on the strategy that worked for us: a [layer-based approach to multi-service migration](/2026/03/05/flip-the-axis-a-layer-based-approach-to-multi-service-migrations/) — parallelizing by step instead of by service, so the same Terraform craft compounds across a fleet.
+
 Thank you for reading down to this point! 🤗
 
 If you have some favorite Terraform tricks — I would love to know!

--- a/content/posts/2024/A-Deep-Dive-Into-Terraform-Static-Code-Analysis-Tools-Features-and-Comparisons/index.md
+++ b/content/posts/2024/A-Deep-Dive-Into-Terraform-Static-Code-Analysis-Tools-Features-and-Comparisons/index.md
@@ -280,6 +280,8 @@ Here's a comprehensive comparison summary to guide your selection of the most su
 
 Integrating a Terraform security scanning into your development pipeline is a proven strategy to boost your security posture. These tools detect potential vulnerabilities early and enforce best practices and compliance standards, representing a proactive approach to infrastructure security.
 
+A scanner can catch the bugs you've thought of. The harder problem is what to do when [a green pipeline still lies](/2026/04/10/the-pipeline-was-green/) — when CI says "safe" but the change is anything but. I wrote about that case separately, including how an AI agent trusted a green build and broke a whole environment for three days.
+
 For teams not yet utilizing these tools, **Checkov** is my top recommendation:
 - Biggest number of default policies and supported Terraform providers for a quick start.
 - Custom policy support in YAML and Python for flexible policy creation.

--- a/content/posts/2025/delegate-for-growth-scaling-your-impact-through-others/index.md
+++ b/content/posts/2025/delegate-for-growth-scaling-your-impact-through-others/index.md
@@ -1,8 +1,9 @@
 ---
-title: "Delegate for Growth: Scaling Your Impact Through Others"
+title: "Delegating Without Authority as a Senior Engineer"
 slug: "delegate-for-growth-scaling-your-impact-through-others"
 date: 2025-04-04T00:36:23+02:00
-description: "Senior IC guide to scaling impact. Master peer influence & growth delegation to effectively lead without formal authority."
+description: "How to delegate work as a senior engineer when you don't manage anyone — peer influence, scaling impact, and leading without formal authority."
+keywords: ["senior engineer delegation", "leading without authority", "scaling impact as IC", "peer influence", "staff engineer leadership", "IC leadership", "delegate as engineer", "influence without authority", "engineering leadership"]
 cover:
     image: cover.jpeg
     relative: true

--- a/content/posts/2025/delegate-for-growth-scaling-your-impact-through-others/index.md
+++ b/content/posts/2025/delegate-for-growth-scaling-your-impact-through-others/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Delegate for Growth: Scaling Your Impact Through Others"
+slug: "delegate-for-growth-scaling-your-impact-through-others"
 date: 2025-04-04T00:36:23+02:00
 description: "Senior IC guide to scaling impact. Master peer influence & growth delegation to effectively lead without formal authority."
 cover:

--- a/content/posts/2026/flip-the-axis-a-layer-based-approach-to-multi-service-migrations/index.md
+++ b/content/posts/2026/flip-the-axis-a-layer-based-approach-to-multi-service-migrations/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Flip the Axis: A Layer-Based Approach to Multi-Service Migrations"
+slug: "flip-the-axis-a-layer-based-approach-to-multi-service-migrations"
 date: 2026-03-05T01:02:07+01:00
 summary: "How parallelizing by step instead of by service helped a half-sized team do twice the work"
 description: "A practical strategy for large-scale service migrations: parallelize by step, not by service, to compound learning, catch errors early, and enable automation"

--- a/content/posts/2026/flip-the-axis-a-layer-based-approach-to-multi-service-migrations/index.md
+++ b/content/posts/2026/flip-the-axis-a-layer-based-approach-to-multi-service-migrations/index.md
@@ -85,7 +85,7 @@ A layer sweep works like this: the team takes on a layer, splits the service lis
 
 One engineer can realistically sweep a single layer across 6-8 services in a day. That number surprises people -- until they know the tooling. We paired the layered methodology with AI-assisted automation that handled the repetitive configuration work across services. But the important thing is: **the layer-based structure is what makes that automation possible**.
 
-When every service needs the same type of change with minor variations, you can build prompts, scripts, and validation checks that apply across the board. Serial, per-service work is too varied to automate effectively. The AI tooling story -- what worked, what failed, and where human judgment was irreplaceable -- is the subject of the next post in this series.
+When every service needs the same type of change with minor variations, you can build prompts, scripts, and validation checks that apply across the board. Serial, per-service work is too varied to automate effectively. The AI tooling story -- what worked, what failed, and where human judgment was irreplaceable -- is the subject of the [follow-up post on harness engineering for infrastructure](/2026/04/07/layers-made-it-universal.-harnesses-made-it-run/).
 
 During execution, the team meets briefly to sync on edge cases -- because the work is homogeneous, an edge case in one service is immediately relevant to every other service going through the same layer.
 

--- a/content/posts/2026/flip-the-axis-a-layer-based-approach-to-multi-service-migrations/index.md
+++ b/content/posts/2026/flip-the-axis-a-layer-based-approach-to-multi-service-migrations/index.md
@@ -1,15 +1,15 @@
 ---
-title: "Flip the Axis: A Layer-Based Approach to Multi-Service Migrations"
+title: "Flip the Axis: Layer-Based Service Migration"
 slug: "flip-the-axis-a-layer-based-approach-to-multi-service-migrations"
 date: 2026-03-05T01:02:07+01:00
 summary: "How parallelizing by step instead of by service helped a half-sized team do twice the work"
-description: "A practical strategy for large-scale service migrations: parallelize by step, not by service, to compound learning, catch errors early, and enable automation"
+description: "A migration pattern for many services: parallelize by step instead of by service. Compound learning, catch errors early, enable automation across services."
 cover:
     image: cover.jpg
     relative: true
-    alt:
+    alt: "Diagram of a service migration flipped from per-service to per-step execution"
 series: ["Engineering Leadership"]
-keywords: ["multi-service migration", "migration strategy", "ECS to EKS migration", "Kubernetes migration", "infrastructure migration at scale", "platform engineering"]
+keywords: ["multi-service migration", "migration strategy", "migration parallelization", "layer-based migration", "ECS to EKS migration", "Kubernetes migration", "infrastructure migration at scale", "platform engineering", "engineering leadership", "scaling migrations"]
 ---
 
 ## TL;DR

--- a/content/posts/2026/full-attendance-zero-presence/index.md
+++ b/content/posts/2026/full-attendance-zero-presence/index.md
@@ -1,16 +1,19 @@
 ---
-title: Full Attendance, Zero Presence
+title: "Full Attendance, Zero Presence in Meetings"
 slug: full-attendance-zero-presence
 date: 2026-03-18T20:04:21+01:00
 summary: Most listening advice says add behaviors. The real fix is the opposite — stop doing everything else.
-description: How presence breaks down in meetings — silent nods, solving before hearing, and what being present actually looks like.
+description: "Active listening in engineering meetings — silent-nod failures, solving before hearing, and what real presence looks like in 1:1s and all-hands."
 keywords:
   - active listening
+  - active listening in meetings
   - meeting presence
   - listening in meetings
   - meeting anti-patterns
   - engineering communication
   - 1:1 meetings
+  - engineering leadership
+  - silent disagreement in meetings
 series: Engineering Leadership
 cover:
   image: cover.jpg

--- a/content/posts/2026/full-attendance-zero-presence/index.md
+++ b/content/posts/2026/full-attendance-zero-presence/index.md
@@ -1,5 +1,6 @@
 ---
 title: Full Attendance, Zero Presence
+slug: full-attendance-zero-presence
 date: 2026-03-18T20:04:21+01:00
 summary: Most listening advice says add behaviors. The real fix is the opposite — stop doing everything else.
 description: How presence breaks down in meetings — silent nods, solving before hearing, and what being present actually looks like.

--- a/content/posts/2026/layers-made-it-universal-harnesses-made-it-run/index.md
+++ b/content/posts/2026/layers-made-it-universal-harnesses-made-it-run/index.md
@@ -1,15 +1,15 @@
 ---
-title: "Layers Made It Universal. Harnesses Made It Run"
+title: "Harness Engineering: Layers Made It Universal"
 slug: "layers-made-it-universal.-harnesses-made-it-run"
 date: 2026-04-07
 summary: "What harness engineering looks like when the work is infrastructure, not application code."
-description: "Harness engineering applied to infrastructure migration, not coding agents. How a prompt pipeline mixing scripts, AI, and validation made a 21-service ECS-to-EKS migration trustworthy -- four engineers, twelve layers, one pipeline."
+description: "Harness engineering for infrastructure: a prompt pipeline mixing scripts, AI, and validation made a 21-service ECS-to-EKS migration trustworthy."
 cover:
     image: cover.png
     relative: true
-    alt: ""
+    alt: "Diagram of a prompt pipeline running across infrastructure repositories"
 series: ["Engineering Leadership"]
-keywords: ["harness engineering", "AI agents", "prompt pipeline", "ECS to EKS migration", "infrastructure automation", "platform engineering", "Claude Code", "AI for DevOps", "AI for infrastructure", "toil automation", "multi-service migration"]
+keywords: ["harness engineering", "AI agents", "AI agents for infrastructure", "prompt pipeline", "ECS to EKS migration", "infrastructure automation", "platform engineering", "Claude Code", "AI for DevOps", "AI for infrastructure", "toil automation", "multi-service migration", "engineering leadership"]
 ---
 
 *A continuation of [Flip the Axis: A Layer-Based Approach to Multi-Service Migrations](https://devdosvid.blog/2026/03/05/flip-the-axis-a-layer-based-approach-to-multi-service-migrations/).*

--- a/content/posts/2026/layers-made-it-universal-harnesses-made-it-run/index.md
+++ b/content/posts/2026/layers-made-it-universal-harnesses-made-it-run/index.md
@@ -102,7 +102,7 @@ So we built a parallel execution wrapper on top of the Claude Agent SDK. Think o
 
 Each session adapts to its repository while following the same workflow. The agent in repo A figures out one logging setup; the agent in repo B figures out a completely different one. Both produce the same kind of report. The engineer opens ten reports instead of writing ten PRs.
 
-This is the automated [flip-the-axis](https://devdosvid.blog/2026/03/05/flip-the-axis-a-layer-based-approach-to-multi-service-migrations/) model. One layer, one workflow, N repos, one human in the loop. All twelve migration layers ran through this pipeline.
+This is the automated form of the [layer-based multi-service migration model](https://devdosvid.blog/2026/03/05/flip-the-axis-a-layer-based-approach-to-multi-service-migrations/) — one layer, one workflow, N repos, one human in the loop. All twelve migration layers ran through this pipeline.
 
 Prompt pipeline + parallel sessions + per-repo reports + human review at the end.
 

--- a/content/posts/2026/layers-made-it-universal-harnesses-made-it-run/index.md
+++ b/content/posts/2026/layers-made-it-universal-harnesses-made-it-run/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Layers Made It Universal. Harnesses Made It Run"
+slug: "layers-made-it-universal.-harnesses-made-it-run"
 date: 2026-04-07
 summary: "What harness engineering looks like when the work is infrastructure, not application code."
 description: "Harness engineering applied to infrastructure migration, not coding agents. How a prompt pipeline mixing scripts, AI, and validation made a 21-service ECS-to-EKS migration trustworthy -- four engineers, twelve layers, one pipeline."

--- a/content/posts/2026/positional-dominance-is-making-you-a-worse-engineer/index.md
+++ b/content/posts/2026/positional-dominance-is-making-you-a-worse-engineer/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Positional Dominance Is Making You a Worse Engineer"
+slug: "positional-dominance-is-making-you-a-worse-engineer"
 date: 2026-02-19T15:41:54+01:00
 summary: When a teammate proposed a better design than mine, my first instinct was to defend my own — not because of logic, but because it was his idea, not mine.
 description: At Staff level, needing to be the source of every best idea — positional dominance — quietly undermines your leadership. Here's the shift to outcome dominance.

--- a/content/posts/2026/positional-dominance-is-making-you-a-worse-engineer/index.md
+++ b/content/posts/2026/positional-dominance-is-making-you-a-worse-engineer/index.md
@@ -1,10 +1,10 @@
 ---
-title: "Positional Dominance Is Making You a Worse Engineer"
+title: "Positional Dominance: A Senior Engineer Trap"
 slug: "positional-dominance-is-making-you-a-worse-engineer"
 date: 2026-02-19T15:41:54+01:00
 summary: When a teammate proposed a better design than mine, my first instinct was to defend my own — not because of logic, but because it was his idea, not mine.
-description: At Staff level, needing to be the source of every best idea — positional dominance — quietly undermines your leadership. Here's the shift to outcome dominance.
-keywords: [positional dominance, outcome dominance, staff engineer leadership, engineering leadership, senior engineer career growth, tech lead mindset, leading without authority]
+description: How staff and senior engineers undermine their own leadership by needing to be the source of every best idea — and the shift to outcome dominance.
+keywords: [positional dominance, outcome dominance, staff engineer leadership, engineering leadership, senior engineer career growth, tech lead mindset, leading without authority, staff engineer anti-pattern, senior engineer ego, design review ego]
 cover:
     image: cover.png
     relative: true

--- a/content/posts/2026/the-pipeline-was-green/index.md
+++ b/content/posts/2026/the-pipeline-was-green/index.md
@@ -1,5 +1,6 @@
 ---
 title: "The Pipeline Was Green"
+slug: "the-pipeline-was-green"
 date: 2026-04-10T22:03:53+02:00
 summary: An AI agent upgraded a Helm chart, the pipeline said green, and QA was broken for three days. The first instinct was to lock everything down. The better answer was harder to accept.
 description: Our CI said green. An AI agent trusted it and broke QA for three days. The problem wasn't the agent -- it was our own false signals.

--- a/content/posts/2026/the-pipeline-was-green/index.md
+++ b/content/posts/2026/the-pipeline-was-green/index.md
@@ -1,14 +1,14 @@
 ---
-title: "The Pipeline Was Green"
+title: "The Pipeline Was Green: AI Agents and CI Trust"
 slug: "the-pipeline-was-green"
 date: 2026-04-10T22:03:53+02:00
 summary: An AI agent upgraded a Helm chart, the pipeline said green, and QA was broken for three days. The first instinct was to lock everything down. The better answer was harder to accept.
-description: Our CI said green. An AI agent trusted it and broke QA for three days. The problem wasn't the agent -- it was our own false signals.
+description: "AI agent in CI/CD: our pipeline said green, the agent trusted it, and it broke QA for three days. The problem wasn't the agent — it was our false signals."
 cover:
     image: cover.png
     relative: true
     alt: "A green spotlight on a tripod standing on cracked red ground"
-keywords: ["AI agent", "CI/CD pipeline", "platform engineering", "AI automation", "Helm chart", "Kubernetes", "AI-friendly repository"]
+keywords: ["AI agent in CI/CD", "AI agents in pipelines", "trusting AI agents", "Renovate Claude Code", "CI signal trustworthiness", "AI for DevOps", "platform engineering", "AI automation", "Helm chart upgrade", "Kubernetes operator", "AI-friendly repository", "engineering leadership"]
 series: ["Engineering Leadership"]
 ---
 

--- a/content/series/engineering-leadership/_index.md
+++ b/content/series/engineering-leadership/_index.md
@@ -1,0 +1,22 @@
+---
+title: "Engineering Leadership"
+description: "Essays on staff-level engineering leadership — leading without authority, scaling impact through peers, presence in meetings, and patterns that shape senior IC growth."
+---
+
+This series collects essays on **engineering leadership at staff and senior IC levels** — the kind of leadership that has nothing to do with formal authority. It's about the patterns I've watched (and lived through) on the way from "deepest technical contributor in the room" to "person whose impact compounds through others."
+
+A few recurring threads I keep coming back to:
+
+**Leading without authority.** The shift from doing the work yourself to multiplying through peers when nobody reports to you. How to get others invested in your priorities without managerial leverage — and what makes that work over time.
+
+**Outcome dominance over positional dominance.** The hidden ego trap of needing to be the source of every best idea, and what changes when you optimize for the project's win instead of yours. Most "be humble" advice is positional thinking with better PR; the real shift is in what you're optimizing for.
+
+**Presence over attendance.** What real listening looks like when meetings get harder, faster, and noisier — and the silent ways "showing up" stops being enough. The damage done by silent nods and disagreements that never enter the room.
+
+**Execution at scale.** Migration patterns, layered execution models, and the harness engineering that turns AI agents into reliable teammates instead of liabilities. Where the methodology enables the tooling, not the other way around.
+
+**Trustworthy signals.** When green pipelines lie, AI agents misjudge, and the systems we built to give us confidence stop being reliable. The work of restoring trust in the signals that production runs on.
+
+The audience is anyone navigating the senior-IC-to-staff transition — the career stretch where technical depth gets out-leveraged by leadership patterns, where "the best idea wins" stops being the only thing that matters, and where your impact starts being measured in the systems and people you grow rather than the code you write.
+
+The posts in this series, in publication order:

--- a/layouts/partials/extend_head.html
+++ b/layouts/partials/extend_head.html
@@ -57,8 +57,8 @@
   ],
   "sameAs": [
     "https://x.com/vasylenko",
-    "https://github.com/vasylenko"
-    {{- /* TODO Serhii: add LinkedIn and any other canonical profile URLs as additional comma-separated items above. */}}
+    "https://github.com/vasylenko",
+    "https://www.linkedin.com/in/svasylenko"
   ]
 }
 </script>

--- a/layouts/partials/extend_head.html
+++ b/layouts/partials/extend_head.html
@@ -40,11 +40,6 @@
     "name": "Superhuman",
     "url": "https://superhuman.com"
   },
-  "alumniOf": {
-    "@type": "Organization",
-    "name": "Grammarly",
-    "url": "https://grammarly.com"
-  },
   "knowsAbout": [
     "Engineering Leadership",
     "Platform Engineering",

--- a/layouts/partials/extend_head.html
+++ b/layouts/partials/extend_head.html
@@ -22,5 +22,46 @@
 {{- end }}
 <meta name="twitter:creator" content="{{ site.Params.twittercreator }}"/>
 <meta name="twitter:site" content="{{ site.Params.twittersite }}"/>
+{{- /* Standalone Person schema on /about/ only — fills the E-E-A-T attribution gap.
+       PaperMod emits Person at home (params.schema.publisherType=Person) and nested
+       inside each post's BlogPosting.author. This block adds a top-level Person
+       graph node specifically on the author page. Gated to avoid duplication. */ -}}
+{{- if eq .RelPermalink "/about/" }}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Person",
+  "name": "Serhii Vasylenko",
+  "url": "{{ site.BaseURL }}about/",
+  "image": "{{ site.BaseURL }}{{ site.Params.opengraphimage | default "/assets/img/websitelogo.jpg" | strings.TrimPrefix "/" }}",
+  "jobTitle": "Staff Platform Engineer",
+  "worksFor": {
+    "@type": "Organization",
+    "name": "Superhuman",
+    "url": "https://superhuman.com"
+  },
+  "alumniOf": {
+    "@type": "Organization",
+    "name": "Grammarly",
+    "url": "https://grammarly.com"
+  },
+  "knowsAbout": [
+    "Engineering Leadership",
+    "Platform Engineering",
+    "Staff Engineer Career",
+    "Leading Without Authority",
+    "Developer Experience",
+    "Infrastructure as Code",
+    "Kubernetes",
+    "AWS"
+  ],
+  "sameAs": [
+    "https://x.com/vasylenko",
+    "https://github.com/vasylenko"
+    {{- /* TODO Serhii: add LinkedIn and any other canonical profile URLs as additional comma-separated items above. */}}
+  ]
+}
+</script>
+{{- end }}
 <!-- 100% privacy-first analytics -->
 <script async src="https://scripts.simpleanalyticscdn.com/latest.js"></script>


### PR DESCRIPTION
## Summary

Structural SEO improvements for the engineering-leadership content cluster. The posts are indexed and technically clean — the gap is in title vocabulary, internal link signals, and site-wide topical signal.

**Slug locks** on all 6 leadership posts — defensive prerequisite so the title rewrites cannot move URLs.

**Site identity** — homepage hero, SEO description, and keywords reframed to give engineering leadership equal billing alongside the existing technical strand. About page prose expanded. Standalone `Person` JSON-LD added in `layouts/partials/extend_head.html`, gated to `/about/` only — fills the author-entity gap (PaperMod's built-in schema only nests `Person` inside per-post `BlogPosting.author`).

**Series hub** — new `content/series/engineering-leadership/_index.md` with original framing copy. PaperMod's default `_default/list.html` renders it above the auto-generated post list, so no template work is needed.

**Per-post rewrites** — new titles, descriptions in the 120–155 char window, and expanded keyword arrays on all 6 leadership posts. Coined brand terms (Positional Dominance, Harness Engineering, Flip the Axis) preserved where they exist; literal search vocabulary front-loaded otherwise. Cover `alt` filled in on 2 posts that had it empty.

**Internal cross-links** — three new descriptive-anchor links from high-authority technical posts into the leadership cluster, plus a missing back-link inside the leadership pair (`flip-the-axis` previously had a text-only "next post" teaser with no hyperlink). Anchor text on the existing reverse link upgraded from a bare slug to a descriptive phrase.

**Person JSON-LD `sameAs`** — populated with verified profile URLs.

## Trade-offs worth flagging

- **Single-title constraint**: PaperMod uses front-matter `.Title` simultaneously for `<title>`, `<h1>`, `og:title`, `twitter:title`, and JSON-LD `headline`. There is no built-in way to set a separate SEO title vs display H1 without a template override (`CLAUDE.md` disallows). New titles are designed to work as both.
- **Skipped tinypng cross-link**: high backlink count but no honest thematic adjacency to any leadership post. A forced link would read as SEO-driven.
- **Pre-existing schema noise on `/about/`**: PaperMod's `schema_json.html` emits `BlogPosting` for any `.IsPage`. Shows up as a third `ld+json` script in production. Not introduced here; fixing requires a template override.

## Verification

- Production build (`docker compose run --rm hugo-runtime --environment production --minify --gc`): 59 pages, no errors or warnings.
- Dev server smoke test: 11 URLs return HTTP 200 (homepage, about, hub, 6 leadership posts, 2 technical cross-link source posts).
- Rendered-HTML assertions against live dev server: meta titles / descriptions / keywords correct on every leadership post; `Person` JSON-LD with `jobTitle` / `alumniOf` / `sameAs` renders only on `/about/` (zero standalone Person on post pages — gate works); cross-links resolve with descriptive anchor text; sitemap regenerated with the hub URL.

## Out of scope

- External syndication (cross-posting, HN submission, outreach to leadership publications) — separate follow-up.
- Title rewrites for technical posts — only the leadership-cluster front matter is touched here.
