### PR TITLE
keepup: parse bucketize replies wrapped in a JSON fence

### DIFF
--- a/keepup/keepup/bucketize.py
+++ b/keepup/keepup/bucketize.py
@@ -17,6 +17,21 @@ _PROMPT = Path(__file__).parent / "prompts" / "bucketize.md"
 _MAX_OUTPUT = 2000
 
 
+def _assignments(reply: str) -> dict[str, str]:
+    """Pull the ID -> bucket map out of the model's reply.
+
+    Workers AI does not honour `response_format: json_object` for this model --
+    it returns the object wrapped in a ```json fence -- so decode from the first
+    brace rather than trusting the whole reply to be JSON. The snippet in the
+    error is what makes the next format surprise diagnosable from the CI log.
+    """
+    try:
+        payload, _ = json.JSONDecoder().raw_decode(reply, reply.index("{"))
+    except ValueError as exc:
+        raise ValueError(f"{exc}; reply began {reply[:120]!r}") from exc
+    return payload.get("assignments", {})
+
+
 def bucketize(topic_name: str, items: list[Item], buckets: list[str], model: str) -> list[str] | None:
     """Assign each item to a bucket by mutating item.source; return the bucket
     roster (display order) on success, or None to fall back to flat grouping.
@@ -42,7 +57,7 @@ def bucketize(topic_name: str, items: list[Item], buckets: list[str], model: str
             max_tokens=_MAX_OUTPUT,
             temperature=0,
         )
-        assignments = json.loads(response.choices[0].message.content).get("assignments", {})
+        assignments = _assignments(response.choices[0].message.content)
     except Exception as exc:
         print(f"  bucketize failed for {topic_name}: {exc}")
         return None

--- a/keepup/tests/test_bucketize.py
+++ b/keepup/tests/test_bucketize.py
@@ -1,0 +1,22 @@
+import pytest
+
+from keepup.bucketize import _assignments
+
+
+def test_parses_reply_wrapped_in_a_json_fence():
+    # What Workers AI actually returns despite response_format=json_object.
+    reply = '```json\n{\n  "assignments": {"6f70dd59": "Compute", "bbef74e9": "Security"}\n}\n```'
+    assert _assignments(reply) == {"6f70dd59": "Compute", "bbef74e9": "Security"}
+
+
+def test_parses_bare_json():
+    assert _assignments('{"assignments": {"a1": "Containers"}}') == {"a1": "Containers"}
+
+
+def test_missing_assignments_key_returns_empty():
+    assert _assignments('{"buckets": []}') == {}
+
+
+def test_reply_without_an_object_raises():
+    with pytest.raises(ValueError):
+        _assignments("I cannot classify these items.")


### PR DESCRIPTION
## Problem

Every AWS section in the digest degrades to a flat `AWS What's New` list instead of the Containers/Security/Compute buckets. Visible now on https://devdosvid.blog/keepup/.

## Root cause

Not the LLM — the parser. Raw response captured from a CI run:

```
"content": "```json\n{\n  \"assignments\": {\n    \"6f70dd59\": \"Compute\",\n    \"bbef74e9\": \"Security\", ... }\n}\n```"
```

Cloudflare's OpenAI-compatible endpoint does not honour `response_format: {"type": "json_object"}` for `@cf/meta/llama-3.3-70b-instruct-fp8-fast`; the object comes back inside a markdown fence. `json.loads()` hits the backticks and raises `Expecting value: line 1 column 1 (char 0)`, which `bucketize()` swallows into its flat-list fallback. The classification itself was correct every time.

## Fix

Decode from the first brace with `JSONDecoder().raw_decode` — same approach already used for the OpenAI release-notes payload. The failure message now carries a snippet of the reply, which is what turned a silent fallback into a five-minute diagnosis.

4 new tests (fenced, bare, missing key, no object at all). Suite: 17 passing.